### PR TITLE
Update (2023.12.07)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -1196,6 +1196,7 @@ class Assembler : public AbstractAssembler  {
     stptr_w_op         = 0b00100101,
     ldptr_d_op         = 0b00100110,
     stptr_d_op         = 0b00100111,
+    csr_op             = 0b00000100,
 
     unknow_ops8        = 0b11111111
   };
@@ -1864,6 +1865,8 @@ public:
   void stptr_w  (Register rd, Register rj, int si16)  { assert(is_simm(si16, 16) && ((si16 & 0x3) == 0), "not a signed 16-bit int"); emit_int32(insn_I14RR(stptr_w_op, si16>>2, (int)rj->encoding(), (int)rd->encoding())); }
   void ldptr_d  (Register rd, Register rj, int si16)  { assert(is_simm(si16, 16) && ((si16 & 0x3) == 0), "not a signed 16-bit int"); emit_int32(insn_I14RR(ldptr_d_op, si16>>2, (int)rj->encoding(), (int)rd->encoding())); }
   void stptr_d  (Register rd, Register rj, int si16)  { assert(is_simm(si16, 16) && ((si16 & 0x3) == 0), "not a signed 16-bit int"); emit_int32(insn_I14RR(stptr_d_op, si16>>2, (int)rj->encoding(), (int)rd->encoding())); }
+  void csrrd  (Register rd, int csr)   { emit_int32(insn_I14RR(csr_op, csr, 0, (int)rd->encoding())); }
+  void csrwr  (Register rd, int csr)   { emit_int32(insn_I14RR(csr_op, csr, 1, (int)rd->encoding())); }
 
   void ld_b  (Register rd, Register rj, int si12)  { assert(is_simm(si12, 12), "not a signed 12-bit int"); emit_int32(insn_I12RR(ld_b_op,  si12, (int)rj->encoding(), (int)rd->encoding())); }
   void ld_h  (Register rd, Register rj, int si12)  { assert(is_simm(si12, 12), "not a signed 12-bit int"); emit_int32(insn_I12RR(ld_h_op,  si12, (int)rj->encoding(), (int)rd->encoding())); }

--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -538,7 +538,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method* m = safe_interpreter_frame_method();
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/loongarch/globals_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/globals_loongarch.hpp
@@ -97,7 +97,9 @@ define_pd_global(intx, AllocatePrefetchDistance,     -1);
           "Use CRC32 instructions for CRC32 computation")                   \
                                                                             \
   product(bool, UseActiveCoresMP, false,                                    \
-                "Eliminate barriers for single active cpu")
+                "Eliminate barriers for single active cpu")                 \
+                                                                            \
+  product(bool, TraceTraps, false, "Trace all traps the signal handler")
 
 // end of ARCH_FLAGS
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -10395,13 +10395,13 @@ instruct ShouldNotReachHere( )
   ins_cost(300);
 
   // Use the following format syntax
-  format %{ "ILLTRAP   ;#@ShouldNotReachHere" %}
+  format %{ "stop; #@ShouldNotReachHere" %}
   ins_encode %{
     if (is_reachable()) {
-      // Here we should emit illtrap!
-      __ stop("ShouldNotReachHere");
+      __ stop(_halt_reason);
     }
   %}
+
   ins_pipe( pipe_jump );
 %}
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -978,22 +978,11 @@ void MacroAssembler::debug(char* msg/*, RegistersForDebugging* regs*/) {
 
 
 void MacroAssembler::stop(const char* msg) {
-  li(A0, (long)msg);
-  call(CAST_FROM_FN_PTR(address, MacroAssembler::debug), relocInfo::runtime_call_type);
-  brk(17);
-}
-
-void MacroAssembler::warn(const char* msg) {
-  push_call_clobbered_registers();
-  li(A0, (long)msg);
-  push(S2);
-  move(S2, SP);     // use S2 as a sender SP holder
-  assert(StackAlignmentInBytes == 16, "must be");
-  bstrins_d(SP, R0, 3, 0); // align stack as required by ABI
-  call(CAST_FROM_FN_PTR(address, MacroAssembler::debug), relocInfo::runtime_call_type);
-  move(SP, S2);     // use S2 as a sender SP holder
-  pop(S2);
-  pop_call_clobbered_registers();
+#ifndef PRODUCT
+  block_comment(msg);
+#endif
+  csrrd(R0, 0);
+  emit_int64((uintptr_t)msg);
 }
 
 void MacroAssembler::increment(Register reg, int imm) {

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -387,9 +387,6 @@ class MacroAssembler: public Assembler {
   // prints msg, dumps registers and stops execution
   void stop(const char* msg);
 
-  // prints msg and continues
-  void warn(const char* msg);
-
   static void debug(char* msg/*, RegistersForDebugging* regs*/);
   static void debug64(char* msg, int64_t pc, int64_t regs[]);
 

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.cpp
@@ -422,6 +422,10 @@ bool NativeInstruction::is_sigill_zombie_not_entrant() {
   return uint_at(0) == NativeIllegalInstruction::instruction_code;
 }
 
+bool NativeInstruction::is_stop() {
+  return uint_at(0) == 0x04000000; // csrrd R0 0
+}
+
 void NativeIllegalInstruction::insert(address code_pos) {
   *(juint*)code_pos = instruction_code;
   ICache::invalidate_range(code_pos, instruction_size);

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -80,6 +80,7 @@ class NativeInstruction {
   inline bool is_NativeCallTrampolineStub_at();
   //We use an illegal instruction for marking a method as not_entrant or zombie.
   bool is_sigill_zombie_not_entrant();
+  bool is_stop();
 
  protected:
   address addr_at(int offset) const    { return address(this) + offset; }

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -893,7 +893,6 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
 
   gen_c2i_adapter(masm, total_args_passed, comp_args_on_stack, sig_bt, regs, skip_fixup);
 
-  __ flush();
   return AdapterHandlerLibrary::new_entry(fingerprint, i2c_entry, c2i_entry, c2i_unverified_entry, c2i_no_clinit_check_entry);
 }
 

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -175,7 +175,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(MaxGCPauseMillis, 650);
+    FLAG_SET_CMDLINE(MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -175,7 +175,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(MaxGCPauseMillis, 150);
+    FLAG_SET_DEFAULT(MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {

--- a/src/hotspot/cpu/mips/stubGenerator_mips_64.cpp
+++ b/src/hotspot/cpu/mips/stubGenerator_mips_64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1905,47 +1905,6 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_arrayof_jint_fill = generate_fill(T_INT, true, "arrayof_jint_fill");
   }
 
-  // add a function to implement SafeFetch32 and SafeFetchN
-  void generate_safefetch(const char* name, int size, address* entry,
-                          address* fault_pc, address* continuation_pc) {
-    // safefetch signatures:
-    //   int      SafeFetch32(int*      adr, int      errValue);
-    //   intptr_t SafeFetchN (intptr_t* adr, intptr_t errValue);
-    //
-    // arguments:
-    //   A0 = adr
-    //   A1 = errValue
-    //
-    // result:
-    //   PPC_RET  = *adr or errValue
-
-    StubCodeMark mark(this, "StubRoutines", name);
-
-    // Entry point, pc or function descriptor.
-    *entry = __ pc();
-
-    // Load *adr into A1, may fault.
-    *fault_pc = __ pc();
-    switch (size) {
-      case 4:
-        // int32_t
-        __ lw(A1, A0, 0);
-        break;
-      case 8:
-        // int64_t
-        __ ld(A1, A0, 0);
-        break;
-      default:
-        ShouldNotReachHere();
-    }
-
-    // return errValue or *adr
-    *continuation_pc = __ pc();
-    __ addu(V0,A1,R0);
-    __ jr(RA);
-    __ delayed()->nop();
-  }
-
 
 #undef __
 #define __ masm->
@@ -2720,14 +2679,6 @@ class StubGenerator: public StubCodeGenerator {
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
 #endif
-
-    // Safefetch stubs.
-    generate_safefetch("SafeFetch32", sizeof(int),     &StubRoutines::_safefetch32_entry,
-                                                       &StubRoutines::_safefetch32_fault_pc,
-                                                       &StubRoutines::_safefetch32_continuation_pc);
-    generate_safefetch("SafeFetchN", sizeof(intptr_t), &StubRoutines::_safefetchN_entry,
-                                                       &StubRoutines::_safefetchN_fault_pc,
-                                                       &StubRoutines::_safefetchN_continuation_pc);
 
 #ifdef COMPILER2
     if (UseMontgomeryMultiplyIntrinsic) {

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -505,7 +505,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  print_instructions(st, pc, 4/*native instruction size*/);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -473,9 +473,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
 
   const ucontext_t* uc = (const ucontext_t*)context;
 
-  intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
-  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
-  print_hex_dump(st, (address)(sp - 32), (address)(sp + 32), sizeof(intptr_t));
+  address sp = (address)os::Linux::ucontext_get_sp(uc);
+  print_tos(st, sp);
   st->cr();
 
   // Note: it may be unsafe to inspect memory near pc. For example, pc may

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -282,6 +282,24 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 #ifdef PRINT_SIGNAL_HANDLE
         tty->print_cr("continuation_for_implicit_exception stub: %lx", stub);
 #endif
+      } else if (sig == SIGILL && nativeInstruction_at(pc)->is_stop()) {
+        // Pull a pointer to the error message out of the instruction
+        // stream.
+        const uint64_t *detail_msg_ptr
+          = (uint64_t*)(pc + 4/*NativeInstruction::instruction_size*/);
+        const char *detail_msg = (const char *)*detail_msg_ptr;
+        const char *msg = "stop";
+        if (TraceTraps) {
+          tty->print_cr("trap: %s: (SIGILL)", msg);
+        }
+
+        // End life with a fatal error, message and detail message and the context.
+        // Note: no need to do any post-processing here (e.g. signal chaining)
+        va_list va_dummy;
+        VMError::report_and_die(thread, uc, nullptr, 0, msg, detail_msg, va_dummy);
+        va_end(va_dummy);
+
+        ShouldNotReachHere();
       }
     } else if ((thread->thread_state() == _thread_in_vm ||
                  thread->thread_state() == _thread_in_native) &&
@@ -487,9 +505,8 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  st->print_cr("Instructions: (pc=" PTR_FORMAT ")", p2i(pc));
-  print_hex_dump(st, pc - 64, pc + 64, sizeof(char));
-  Disassembler::decode(pc - 80, pc + 80, st);
+  print_instructions(st, pc, 4/*native instruction size*/);
+  st->cr();
 }
 
 void os::setup_fpu() {

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -423,6 +423,7 @@ void os::print_context(outputStream *st, const void *context) {
   if (context == NULL) return;
 
   const ucontext_t *uc = (const ucontext_t*)context;
+
   st->print_cr("Registers:");
   st->print(  "ZERO=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.__gregs[0]);
   st->print(", RA=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.__gregs[1]);
@@ -465,6 +466,12 @@ void os::print_context(outputStream *st, const void *context) {
   st->print(", S8=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.__gregs[31]);
   st->cr();
   st->cr();
+}
+
+void os::print_tos_pc(outputStream *st, const void *context) {
+  if (context == NULL) return;
+
+  const ucontext_t* uc = (const ucontext_t*)context;
 
   intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
   st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -129,6 +129,12 @@ frame os::fetch_frame_from_context(const void* ucVoid) {
   intptr_t* sp;
   intptr_t* fp;
   address epc = fetch_frame_from_context(ucVoid, &sp, &fp);
+  if (!is_readable_pointer(epc)) {
+    // Try to recover from calling into bad memory
+    // Assume new frame has not been set up, the same as
+    // compiled frame stack bang
+    return fetch_compiled_frame_from_context(ucVoid);
+  }
   return frame(sp, fp, epc);
 }
 
@@ -480,7 +486,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // Note: it may be unsafe to inspect memory near pc. For example, pc may
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
-  address pc = os::Posix::ucontext_get_pc(uc);
+  address pc = os::fetch_frame_from_context(uc).pc();
   st->print_cr("Instructions: (pc=" PTR_FORMAT ")", p2i(pc));
   print_hex_dump(st, pc - 64, pc + 64, sizeof(char));
   Disassembler::decode(pc - 80, pc + 80, st);

--- a/src/hotspot/os_cpu/linux_loongarch/safefetch_linux_loongarch64.S
+++ b/src/hotspot/os_cpu/linux_loongarch/safefetch_linux_loongarch64.S
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+    .globl SafeFetchN_impl
+    .globl _SafeFetchN_fault
+    .globl _SafeFetchN_continuation
+    .globl SafeFetch32_impl
+    .globl _SafeFetch32_fault
+    .globl _SafeFetch32_continuation
+
+    # Support for int SafeFetch32(int* address, int defaultval);
+    #
+    #  a0 : address
+    #  a1 : defaultval
+SafeFetch32_impl:
+_SafeFetch32_fault:
+    ld.w  $r4, $r4, 0
+    jr    $r1
+_SafeFetch32_continuation:
+    or    $r4, $r5, $r0
+    jr    $r1
+
+    # Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    #
+    #  a0 : address
+    #  a1 : defaultval
+SafeFetchN_impl:
+_SafeFetchN_fault:
+    ld.d  $r4, $r4, 0
+    jr    $r1
+_SafeFetchN_continuation:
+    or    $r4, $r5, $r0
+    jr    $r1

--- a/src/hotspot/os_cpu/linux_mips/os_linux_mips.cpp
+++ b/src/hotspot/os_cpu/linux_mips/os_linux_mips.cpp
@@ -720,6 +720,7 @@ void os::print_context(outputStream *st, const void *context) {
   if (context == NULL) return;
 
   const ucontext_t *uc = (const ucontext_t*)context;
+
   st->print_cr("Registers:");
   st->print(  "R0=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[0]);
   st->print(", AT=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[1]);
@@ -762,6 +763,12 @@ void os::print_context(outputStream *st, const void *context) {
   st->print(", RA=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[31]);
   st->cr();
   st->cr();
+}
+
+void os::print_tos_pc(outputStream *st, const void *context) {
+  if (context == NULL) return;
+
+  const ucontext_t* uc = (const ucontext_t*)context;
 
   intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
   st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));

--- a/src/hotspot/os_cpu/linux_mips/safefetch_linux_mips64.S
+++ b/src/hotspot/os_cpu/linux_mips/safefetch_linux_mips64.S
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Loongson Technology. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+    .globl SafeFetchN_impl
+    .globl _SafeFetchN_fault
+    .globl _SafeFetchN_continuation
+    .globl SafeFetch32_impl
+    .globl _SafeFetch32_fault
+    .globl _SafeFetch32_continuation
+
+    # Support for int SafeFetch32(int* address, int defaultval);
+    #
+    #  a0 : address
+    #  a1 : defaultval
+SafeFetch32_impl:
+_SafeFetch32_fault:
+    lw    $2, 0($4)
+    j     $31
+    nop
+_SafeFetch32_continuation:
+    or    $2, $5, $0
+    j     $31
+    nop
+
+    # Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    #
+    #  a0 : address
+    #  a1 : defaultval
+SafeFetchN_impl:
+_SafeFetchN_fault:
+    ld    $2, 0($4)
+    j     $31
+    nop
+_SafeFetchN_continuation:
+    or    $2, $5, $0
+    j     $31
+    nop


### PR DESCRIPTION
32519: Fix for 31967 set default MaxGCPauseMillis
31967: [G1GC] Set default MaxGCPauseMillis=150ms
32564: MIPS port of 8284273: Early crashes in os::print_context on AArch64
32563: MIPS port of 8283326: Implement SafeFetch statically
32186: LA port of 8314020: Print instruction blocks in byte units
31295: Provide information when hitting a HaltNode
28314: Misc crash dump improvements
28096: LA port of 8293851: hs_err should print more stack in hex dump
26263: LA port of 8284273: Early crashes in os::print_context on AArch64
32079: LA port of 8313796: AsyncGetCallTrace crash on unreadable interpreter method pointer
30410: LA port of 8303154: Investigate and improve instruction cache flushing during compilation
23671: MIPS/LA port of 8277417: C1 LIR instruction for load-klass
25388: LA port of 8283326: Implement SafeFetch statically