### PR TITLE
Update (2024.10.17)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -6444,6 +6444,17 @@ instruct membar_storestore() %{
   ins_pipe(empty);
 %}
 
+instruct same_addr_load_fence() %{
+  match(SameAddrLoadFence);
+  ins_cost(400);
+
+  format %{ "MEMBAR @ same_addr_load_fence" %}
+  ins_encode %{
+    __ dbar(0x700);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 //----------Move Instructions--------------------------------------------------
 instruct castX2P(mRegP dst, mRegL src) %{
   match(Set dst (CastX2P src));

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 // FORMS.CPP - Definitions for ADL Parser Forms Classes
 #include "adlc.hpp"
 
@@ -4124,6 +4130,7 @@ bool MatchRule::is_ideal_membar() const {
     !strcmp(_opType,"MemBarVolatile") ||
     !strcmp(_opType,"MemBarCPUOrder") ||
     !strcmp(_opType,"MemBarStoreStore") ||
+    !strcmp(_opType,"SameAddrLoadFence" ) ||
     !strcmp(_opType,"OnSpinWait");
 }
 

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
@@ -266,6 +272,8 @@ public:
 
     bool is_volatile = (decorators & MO_SEQ_CST) != 0;
     bool is_acquire = (decorators & MO_ACQUIRE) != 0;
+    bool is_relaxed = (decorators & MO_RELAXED) != 0;
+    bool is_unsafe = (decorators & C2_UNSAFE_ACCESS) != 0;
 
     // If reference is volatile, prevent following volatiles ops from
     // floating up before the volatile access.
@@ -299,6 +307,13 @@ public:
         assert(_leading_membar == NULL || support_IRIW_for_not_multiple_copy_atomic_cpu, "no leading membar expected");
         Node* mb = kit->insert_mem_bar(Op_MemBarAcquire, n);
         mb->as_MemBar()->set_trailing_load();
+      } else if (is_relaxed && is_unsafe) {
+#ifdef LOONGARCH64
+        assert(kit != nullptr, "unsupported at optimization time");
+        Node* n = _access.raw_access();
+        Node* mb = kit->insert_mem_bar(Op_SameAddrLoadFence, n);
+        mb->as_MemBar()->set_trailing_load();
+#endif
       }
     }
   }

--- a/src/hotspot/share/opto/classes.hpp
+++ b/src/hotspot/share/opto/classes.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "utilities/macros.hpp"
 
 // The giant table of Node classes.
@@ -223,6 +229,7 @@ macro(StoreStoreFence)
 macro(MemBarReleaseLock)
 macro(MemBarVolatile)
 macro(MemBarStoreStore)
+macro(SameAddrLoadFence)
 macro(MergeMem)
 macro(MinI)
 macro(MinL)

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "jvm_io.h"
 #include "asm/macroAssembler.hpp"
@@ -3522,6 +3528,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       n->set_req(MemBarNode::Precedent, top());
     }
     break;
+  case Op_SameAddrLoadFence:
   case Op_MemBarAcquire: {
     if (n->as_MemBar()->trailing_load() && n->req() > MemBarNode::Precedent) {
       // At parse time, the trailing MemBarAcquire for a volatile load

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
 #include "compiler/compileLog.hpp"
@@ -3298,6 +3304,7 @@ MemBarNode* MemBarNode::make(Compile* C, int opcode, int atp, Node* pn) {
   case Op_MemBarReleaseLock: return new MemBarReleaseLockNode(C, atp, pn);
   case Op_MemBarVolatile:    return new MemBarVolatileNode(C, atp, pn);
   case Op_MemBarCPUOrder:    return new MemBarCPUOrderNode(C, atp, pn);
+  case Op_SameAddrLoadFence: return new SameAddrLoadFenceNode(C, atp, pn);
   case Op_OnSpinWait:        return new OnSpinWaitNode(C, atp, pn);
   case Op_Initialize:        return new InitializeNode(C, atp, pn);
   default: ShouldNotReachHere(); return nullptr;

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef SHARE_OPTO_MEMNODE_HPP
 #define SHARE_OPTO_MEMNODE_HPP
 
@@ -1334,6 +1340,14 @@ public:
     : MemBarNode(C, alias_idx, precedent) {}
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return 0; } // not matched in the AD file
+};
+
+// Used to prevent LoadLoad reorder for same address.
+class SameAddrLoadFenceNode: public MemBarNode {
+public:
+  SameAddrLoadFenceNode(Compile* C, int alias_idx, Node* precedent)
+    : MemBarNode(C, alias_idx, precedent) {}
+  virtual int Opcode() const;
 };
 
 class OnSpinWaitNode: public MemBarNode {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "cds/filemap.hpp"
 #include "ci/ciField.hpp"
@@ -1597,6 +1603,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_c2_type(StoreFenceNode, MemBarNode)                             \
   declare_c2_type(MemBarVolatileNode, MemBarNode)                         \
   declare_c2_type(MemBarCPUOrderNode, MemBarNode)                         \
+  declare_c2_type(SameAddrLoadFenceNode, MemBarNode)                      \
   declare_c2_type(OnSpinWaitNode, MemBarNode)                             \
   declare_c2_type(BlackholeNode, MultiNode)                               \
   declare_c2_type(InitializeNode, MemBarNode)                             \

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -52,7 +52,7 @@ public class Disconnect {
         if (IPSupport.hasIPv4()) {
             // test with IPv4 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-                InetAddress lo4 = InetAddress.ofLiteral("127.0.0.1");
+                InetAddress lo4 = InetAddress.getByName("127.0.0.1");
                 System.out.println("Testing with INET family and " + lo4);
                 test(dc, lo4);
                 test(dc, lo4);
@@ -62,7 +62,7 @@ public class Disconnect {
         if (IPSupport.hasIPv6()) {
             // test with IPv6 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
-                InetAddress lo6 = InetAddress.ofLiteral("::1");
+                InetAddress lo6 = InetAddress.getByName("::1");
                 System.out.println("Testing with INET6 family and " + lo6);
                 test(dc, lo6);
                 test(dc, lo6);


### PR DESCRIPTION
11541: Prevent load reorder of VarHandle::getOpaque
34943: 8338748: [17u,21u] Test Disconnect.java compile error: cannot find symbol after JDK-8299813