### PR TITLE
Update (2025.10.29)

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -712,7 +712,8 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
   endif
 
   LIBSPLASHSCREEN_CFLAGS += -DSPLASHSCREEN -DPNG_NO_MMX_CODE \
-                            -DPNG_ARM_NEON_OPT=0 -DPNG_ARM_NEON_IMPLEMENTATION=0
+                            -DPNG_ARM_NEON_OPT=0 -DPNG_ARM_NEON_IMPLEMENTATION=0 \
+                            -DPNG_LOONGARCH_LSX_OPT=0
 
   ifeq ($(call isTargetOs, linux), true)
     ifeq ($(call isTargetCpuArch, ppc), true)

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2025, These
+ * modifications are Copyright (c) 2025, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/systemDictionary.hpp"
@@ -2640,6 +2646,9 @@ void G1CMTask::do_marking_step(double time_target_ms,
   // Since we've done everything else, we can now totally drain the
   // local queue and global stack.
   drain_local_queue(false);
+  // Load of _age._fields._top in drain_local_queue must not pass
+  // the load of _age._fields._top in assert _task_queue->size().
+  LOONGARCH64_ONLY(DEBUG_ONLY(OrderAccess::loadload();))
   drain_global_stack(false);
 
   // Attempt at work stealing from other task's queues.
@@ -2659,6 +2668,9 @@ void G1CMTask::do_marking_step(double time_target_ms,
         // And since we're towards the end, let's totally drain the
         // local queue and global stack.
         drain_local_queue(false);
+        // Load of _age._fields._top in drain_local_queue must not pass
+        // the load of _age._fields._top in assert _task_queue->size().
+        LOONGARCH64_ONLY(DEBUG_ONLY(OrderAccess::loadload();))
         drain_global_stack(false);
       } else {
         break;


### PR DESCRIPTION
20405: Fix assert(partially || _task_queue->size() == 0) by preventing loadload reordering
36366: 8364177: JDK fails to build due to undefined symbol in libpng on LoongArch64