### PR TITLE
Update (2025.10.29)

### DIFF
--- a/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/assembler_loongarch.hpp
@@ -1963,7 +1963,7 @@ public:
   void dbar(int hint)      {
     assert(is_uimm(hint, 15), "not a unsigned 15-bit int");
 
-    if (os::is_ActiveCoresMP())
+    if (UseActiveCoresMP)
       andi(R0, R0, 0);
     else
       emit_int32(insn_I15(dbar_op, hint));

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -420,7 +420,7 @@ void VM_Version::get_processor_features() {
       FLAG_SET_DEFAULT(UseActiveCoresMP, false);
     }
   } else { // !UseActiveCoresMP
-    if (FLAG_IS_DEFAULT(UseActiveCoresMP) && !os::is_MP()) {
+    if (FLAG_IS_DEFAULT(UseActiveCoresMP) && os::Linux::sched_active_processor_count() == 1) {
       FLAG_SET_DEFAULT(UseActiveCoresMP, true);
     }
   }

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -31,6 +31,7 @@
 #include "runtime/java.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/vm_version.hpp"
+#include "os_linux.hpp"
 #ifdef TARGET_OS_FAMILY_linux
 # include "os_linux.inline.hpp"
 #endif
@@ -410,6 +411,17 @@ void VM_Version::get_processor_features() {
     if (!FLAG_IS_DEFAULT(UsePopCountInstruction))
       warning("PopCountI/L/VI(4) employs LSX whereas PopCountVI(8) hinges on LASX.");
     FLAG_SET_DEFAULT(UsePopCountInstruction, false);
+  }
+
+  if (UseActiveCoresMP) {
+    if (os::Linux::sched_active_processor_count() != 1) {
+      if (!FLAG_IS_DEFAULT(UseActiveCoresMP))
+        warning("UseActiveCoresMP disabled because active processors are more than one.");
+      FLAG_SET_DEFAULT(UseActiveCoresMP, false);
+    }
+  } else {
+    if (!os::is_MP())
+      FLAG_SET_DEFAULT(UseActiveCoresMP, true);
   }
 
   UNSUPPORTED_OPTION(CriticalJNINatives);

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -419,9 +419,10 @@ void VM_Version::get_processor_features() {
         warning("UseActiveCoresMP disabled because active processors are more than one.");
       FLAG_SET_DEFAULT(UseActiveCoresMP, false);
     }
-  } else {
-    if (!os::is_MP())
+  } else { // !UseActiveCoresMP
+    if (FLAG_IS_DEFAULT(UseActiveCoresMP) && !os::is_MP()) {
       FLAG_SET_DEFAULT(UseActiveCoresMP, true);
+    }
   }
 
   UNSUPPORTED_OPTION(CriticalJNINatives);

--- a/src/hotspot/cpu/mips/assembler_mips.hpp
+++ b/src/hotspot/cpu/mips/assembler_mips.hpp
@@ -1200,7 +1200,7 @@ public:
   void swr  (Register rt, Register base, int off)     { emit_long(insn_ORRI(swr_op,   (int)base->encoding(), (int)rt->encoding(), off)); }
   void synci(Register base, int off)                  { emit_long(insn_ORRI(regimm_op, (int)base->encoding(), synci_op, off)); }
   void sync ()                                        {
-    if (os::is_ActiveCoresMP())
+    if (UseActiveCoresMP)
       emit_long(0);
     else
       emit_long(sync_op);

--- a/src/hotspot/cpu/mips/vm_version_mips.cpp
+++ b/src/hotspot/cpu/mips/vm_version_mips.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2025, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -445,21 +445,29 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
+  if (UseSHA1Intrinsics) {
+    warning("Intrinsics for SHA-1 crypto hash functions not available on this CPU.");
+    FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
+  }
+
+  if (UseSHA256Intrinsics) {
+    warning("Intrinsics for SHA-224 and SHA-256 crypto hash functions not available on this CPU.");
+    FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
+  }
+
+  if (UseSHA512Intrinsics) {
+    warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
+    FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
+  }
+
   if (UseSHA3Intrinsics) {
-    warning("SHA3 intrinsics are not available on this CPU.");
+    warning("Intrinsics for SHA3-224, SHA3-256, SHA3-384 and SHA3-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA3Intrinsics, false);
   }
 
   if (UseMD5Intrinsics) {
     warning("MD5 intrinsics are not available on this CPU");
     FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
-  }
-
-  if (UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics) {
-    warning("SHA intrinsics are not available on this CPU");
-    FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
-    FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
-    FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
   }
 
   if (UseAES) {

--- a/src/hotspot/cpu/mips/vm_version_mips.cpp
+++ b/src/hotspot/cpu/mips/vm_version_mips.cpp
@@ -511,6 +511,17 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
+  if (UseActiveCoresMP) {
+    if (os::Linux::sched_active_processor_count() != 1) {
+      if (!FLAG_IS_DEFAULT(UseActiveCoresMP))
+        warning("UseActiveCoresMP disabled because active processors are more than one.");
+      FLAG_SET_DEFAULT(UseActiveCoresMP, false);
+    }
+  } else {
+    if (!os::is_MP())
+      FLAG_SET_DEFAULT(UseActiveCoresMP, true);
+  }
+
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -24,8 +24,8 @@
  */
 
 /*
- * This file has been modified by Loongson Technology in 2021. These
- * modifications are Copyright (c) 2021 Loongson Technology, and are made
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2021, 2023 Loongson Technology, and are made
  * available on the same license terms set forth above.
  */
 
@@ -2236,6 +2236,12 @@ bool os::Linux::query_process_memory_info(os::Linux::meminfo_t* info) {
     return true;
   }
   return false;
+}
+
+int os::Linux::sched_active_processor_count() {
+  if (OSContainer::is_containerized())
+    return OSContainer::active_processor_count();
+  return os::Linux::active_processor_count();
 }
 
 #ifdef __GLIBC__

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023. These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #ifndef OS_LINUX_OS_LINUX_HPP
 #define OS_LINUX_OS_LINUX_HPP
 
@@ -190,6 +196,8 @@ class Linux {
   // Stack repair handling
 
   // none present
+
+  static int sched_active_processor_count();
 
  private:
   static void numa_init();

--- a/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,13 @@
 #ifndef OS_CPU_LINUX_LOONGARCH_ORDERACCESS_LINUX_LOONGARCH_HPP
 #define OS_CPU_LINUX_LOONGARCH_ORDERACCESS_LINUX_LOONGARCH_HPP
 
+#include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 
 // Included in orderAccess.hpp header file.
 
 // Implementation of class OrderAccess.
-#define inlasm_sync(v) if (os::is_ActiveCoresMP()) \
-                        __asm__ __volatile__ ("nop"   : : : "memory"); \
-                      else \
+#define inlasm_sync(v) if (!UseActiveCoresMP) \
                         __asm__ __volatile__ ("dbar %0"   : :"K"(v) : "memory");
 #define inlasm_synci() __asm__ __volatile__ ("ibar 0"   : : : "memory");
 

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -522,8 +522,4 @@ void os::verify_stack_alignment() {
 int os::extra_bang_size_in_bytes() {
   // LA does not require the additional stack bang.
   return 0;
-}
-
-bool os::is_ActiveCoresMP() {
-  return UseActiveCoresMP && _initial_active_processor_count == 1;
 }

--- a/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/os_linux_loongarch.hpp
@@ -33,6 +33,4 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
-  static bool is_ActiveCoresMP();
-
 #endif // OS_CPU_LINUX_LOONGARCH_OS_LINUX_LOONGARCH_HPP

--- a/src/hotspot/os_cpu/linux_mips/orderAccess_linux_mips.hpp
+++ b/src/hotspot/os_cpu/linux_mips/orderAccess_linux_mips.hpp
@@ -26,14 +26,13 @@
 #ifndef OS_CPU_LINUX_MIPS_VM_ORDERACCESS_LINUX_MIPS_HPP
 #define OS_CPU_LINUX_MIPS_VM_ORDERACCESS_LINUX_MIPS_HPP
 
+#include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 
 // Included in orderAccess.hpp header file.
 
 // Implementation of class OrderAccess.
-#define inlasm_sync() if (os::is_ActiveCoresMP()) \
-                        __asm__ __volatile__ ("nop"   : : : "memory"); \
-                      else \
+#define inlasm_sync() if (!UseActiveCoresMP) \
                         __asm__ __volatile__ ("sync"   : : : "memory");
 #define inlasm_synci() __asm__ __volatile__ ("synci 0($0)"   : : : "memory");
 

--- a/src/hotspot/os_cpu/linux_mips/os_linux_mips.cpp
+++ b/src/hotspot/os_cpu/linux_mips/os_linux_mips.cpp
@@ -811,7 +811,3 @@ int os::extra_bang_size_in_bytes() {
   // MIPS does not require the additional stack bang.
   return 0;
 }
-
-bool os::is_ActiveCoresMP() {
-  return UseActiveCoresMP && _initial_active_processor_count == 1;
-}

--- a/src/hotspot/os_cpu/linux_mips/os_linux_mips.hpp
+++ b/src/hotspot/os_cpu/linux_mips/os_linux_mips.hpp
@@ -34,6 +34,4 @@
   // Note: Currently only used in 64 bit Windows implementations
   static bool register_code_area(char *low, char *high) { return true; }
 
-  static bool is_ActiveCoresMP();
-
 #endif // OS_CPU_LINUX_MIPS_VM_OS_LINUX_MIPS_HPP


### PR DESCRIPTION
36524: UseActiveCoresMP is enabled by default for single active core
30520: UseActiveCoresMP should be able to be turned off on a single-core machine
27906: Inline ActiveCoresMP
36515: [MIPS] compiler/intrinsics/sha/cli/TestUseSHA*IntrinsicsOptionOnUnsupportedCPU.java failed